### PR TITLE
add dark theme toggle with light/dark/system modes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "interstellar-ice",
-  "version": "0.0.1",
+  "name": "bobby-galli-blog",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "interstellar-ice",
-      "version": "0.0.1",
+      "name": "bobby-galli-blog",
+      "version": "1.0.0",
       "dependencies": {
         "@astrojs/mdx": "^4.3.13",
         "@tailwindcss/vite": "^4.1.18",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -47,6 +47,22 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+    <!-- Theme initialization (prevents flash) -->
+    <script is:inline>
+      (function() {
+        const storedTheme = localStorage.getItem('theme');
+        const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+        if (storedTheme === 'dark' || storedTheme === 'light') {
+          document.documentElement.setAttribute('data-theme', storedTheme);
+        } else if (systemDark) {
+          document.documentElement.setAttribute('data-theme', 'dark');
+        } else {
+          document.documentElement.removeAttribute('data-theme');
+        }
+      })();
+    </script>
   </head>
   <body class="min-h-screen flex flex-col">
     <header class="sticky top-0 z-50 bg-cream/95 backdrop-blur-sm border-b border-cream-dark">
@@ -91,6 +107,43 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
               <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
             </svg>
           </a>
+          <!-- Theme Toggle -->
+          <div class="theme-toggle-wrapper relative">
+            <button class="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
+              <!-- Sun icon (light mode) -->
+              <svg class="icon-sun" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
+              </svg>
+              <!-- Moon icon (dark mode) -->
+              <svg class="icon-moon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
+              </svg>
+              <!-- System icon (auto mode) -->
+              <svg class="icon-system" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+              </svg>
+            </button>
+            <div class="theme-menu">
+              <button data-theme-value="light">
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
+                </svg>
+                Light
+              </button>
+              <button data-theme-value="dark">
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
+                </svg>
+                Dark
+              </button>
+              <button data-theme-value="system">
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                </svg>
+                System
+              </button>
+            </div>
+          </div>
         </div>
       </nav>
     </header>
@@ -146,5 +199,69 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
         </div>
       </div>
     </footer>
+
+    <!-- Theme toggle script -->
+    <script is:inline>
+      (function() {
+        const themeButtons = document.querySelectorAll('[data-theme-value]');
+        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+        function getStoredTheme() {
+          return localStorage.getItem('theme');
+        }
+
+        function applyTheme(theme) {
+          if (theme === 'system') {
+            localStorage.removeItem('theme');
+            if (mediaQuery.matches) {
+              document.documentElement.setAttribute('data-theme', 'dark');
+            } else {
+              document.documentElement.removeAttribute('data-theme');
+            }
+          } else {
+            localStorage.setItem('theme', theme);
+            document.documentElement.setAttribute('data-theme', theme);
+          }
+          updateActiveButton();
+        }
+
+        function updateActiveButton() {
+          const storedTheme = getStoredTheme();
+          themeButtons.forEach(btn => {
+            const value = btn.getAttribute('data-theme-value');
+            if (storedTheme === null && value === 'system') {
+              btn.classList.add('active');
+            } else if (storedTheme === value) {
+              btn.classList.add('active');
+            } else {
+              btn.classList.remove('active');
+            }
+          });
+        }
+
+        // Handle button clicks
+        themeButtons.forEach(btn => {
+          btn.addEventListener('click', () => {
+            const theme = btn.getAttribute('data-theme-value');
+            applyTheme(theme);
+          });
+        });
+
+        // Listen for system theme changes
+        mediaQuery.addEventListener('change', (e) => {
+          const storedTheme = getStoredTheme();
+          if (!storedTheme) {
+            if (e.matches) {
+              document.documentElement.setAttribute('data-theme', 'dark');
+            } else {
+              document.documentElement.removeAttribute('data-theme');
+            }
+          }
+        });
+
+        // Initial state
+        updateActiveButton();
+      })();
+    </script>
   </body>
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,6 +32,29 @@ body {
   background-color: var(--color-cream);
   color: var(--color-charcoal);
   line-height: 1.7;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+/* Dark theme variables */
+html[data-theme="dark"] {
+  --color-timber: #e8dcc8;
+  --color-timber-light: #f5efe4;
+  --color-barn-red: #e5614a;
+  --color-barn-red-light: #f07a66;
+  --color-sage: #8fb87f;
+  --color-sage-light: #a5c998;
+  --color-cream: #1a1a1a;
+  --color-cream-dark: #2d2d2d;
+  --color-stone: #a0a0a0;
+  --color-stone-light: #b5b5b5;
+  --color-charcoal: #e8e8e8;
+  --color-gold: #f0c56a;
+  --color-gold-light: #f5d48a;
+}
+
+/* Override Tailwind bg-white for dark mode */
+html[data-theme="dark"] .bg-white {
+  background-color: var(--color-cream-dark) !important;
 }
 
 /* Typography */
@@ -393,12 +416,21 @@ h1, h2, h3, h4, h5, h6 {
   background: white;
   border-radius: 1rem;
   box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.3s ease;
+}
+
+html[data-theme="dark"] .card {
+  background: var(--color-cream-dark);
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.3);
 }
 
 .card:hover {
   transform: translateY(-2px);
   box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+}
+
+html[data-theme="dark"] .card:hover {
+  box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.4), 0 4px 6px -4px rgb(0 0 0 / 0.4);
 }
 
 /* Tag styles */
@@ -432,12 +464,22 @@ h1, h2, h3, h4, h5, h6 {
   transform: translateY(0);
   transition:
     transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
-    box-shadow 0.25s ease;
+    box-shadow 0.25s ease,
+    background-color 0.3s ease;
+}
+
+html[data-theme="dark"] .exp-card {
+  background: var(--color-cream-dark);
+  box-shadow: 0 2px 8px -2px rgb(0 0 0 / 0.3);
 }
 
 .exp-card:hover {
   transform: translateY(-6px);
   box-shadow: 0 16px 32px -8px rgb(0 0 0 / 0.12);
+}
+
+html[data-theme="dark"] .exp-card:hover {
+  box-shadow: 0 16px 32px -8px rgb(0 0 0 / 0.4);
 }
 
 .exp-card:active {
@@ -488,6 +530,119 @@ h1, h2, h3, h4, h5, h6 {
 
 .exp-card.active .exp-card-desc > span {
   padding-top: 0.75rem;
+}
+
+/* Theme toggle */
+.theme-toggle {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: none;
+  background: transparent;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  color: var(--color-stone);
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.theme-toggle:hover {
+  color: var(--color-timber);
+  background: var(--color-cream-dark);
+}
+
+html[data-theme="dark"] .theme-toggle:hover {
+  background: rgb(255 255 255 / 0.1);
+}
+
+.theme-toggle svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  transition: transform 0.3s ease, opacity 0.2s ease;
+}
+
+.theme-toggle .icon-sun,
+.theme-toggle .icon-moon,
+.theme-toggle .icon-system {
+  position: absolute;
+}
+
+.theme-toggle .icon-sun { opacity: 0; transform: rotate(-90deg) scale(0.5); }
+.theme-toggle .icon-moon { opacity: 0; transform: rotate(90deg) scale(0.5); }
+.theme-toggle .icon-system { opacity: 1; transform: rotate(0) scale(1); }
+
+html[data-theme="light"] .theme-toggle .icon-sun { opacity: 1; transform: rotate(0) scale(1); }
+html[data-theme="light"] .theme-toggle .icon-moon { opacity: 0; transform: rotate(90deg) scale(0.5); }
+html[data-theme="light"] .theme-toggle .icon-system { opacity: 0; transform: rotate(-90deg) scale(0.5); }
+
+html[data-theme="dark"] .theme-toggle .icon-sun { opacity: 0; transform: rotate(-90deg) scale(0.5); }
+html[data-theme="dark"] .theme-toggle .icon-moon { opacity: 1; transform: rotate(0) scale(1); }
+html[data-theme="dark"] .theme-toggle .icon-system { opacity: 0; transform: rotate(90deg) scale(0.5); }
+
+/* Theme dropdown menu */
+.theme-menu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  min-width: 140px;
+  padding: 0.5rem;
+  background: white;
+  border-radius: 0.75rem;
+  box-shadow: 0 10px 40px -10px rgb(0 0 0 / 0.2), 0 0 0 1px rgb(0 0 0 / 0.05);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-8px) scale(0.95);
+  transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
+  z-index: 100;
+}
+
+html[data-theme="dark"] .theme-menu {
+  background: var(--color-cream-dark);
+  box-shadow: 0 10px 40px -10px rgb(0 0 0 / 0.5), 0 0 0 1px rgb(255 255 255 / 0.1);
+}
+
+.theme-toggle-wrapper:focus-within .theme-menu,
+.theme-toggle-wrapper:hover .theme-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+}
+
+.theme-menu button {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  background: transparent;
+  border: none;
+  border-radius: 0.5rem;
+  color: var(--color-stone);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.theme-menu button:hover {
+  background: var(--color-cream-dark);
+  color: var(--color-timber);
+}
+
+html[data-theme="dark"] .theme-menu button:hover {
+  background: rgb(255 255 255 / 0.1);
+}
+
+.theme-menu button.active {
+  color: var(--color-barn-red);
+}
+
+.theme-menu button svg {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
 }
 
 /* Animations */


### PR DESCRIPTION
- Add dark theme CSS variables that override the light theme colors
- Add theme toggle dropdown in the header navigation
- Support system preference detection via prefers-color-scheme
- Persist theme preference in localStorage
- Prevent flash of wrong theme on page load